### PR TITLE
[feature][green] pass testcase test_read명령어_LBA주소가_입력되지않은경우에도_정상실행되며_…

### DIFF
--- a/src/ssd.py
+++ b/src/ssd.py
@@ -1,8 +1,9 @@
+import sys
 from src.ssd_file_manager import SSDFileManager
 
 class SSD():
     def __init__(self):
-        self.nand = [0 for _ in range(100)]
+        self.nand = ["0x00000000" for _ in range(100)]
         self.ssd_file_manager = SSDFileManager()
 
     def select_file_manager(self, file_manager):
@@ -14,35 +15,54 @@ class SSD():
     def _is_valid_value(self, value):
         return isinstance(value, str) and value.startswith("0x") and len(value) == 10
 
-    def Read(self, address):
+    def read(self, address=-1):
         if not self._is_valid_lba(address):
             self.ssd_file_manager.print_ssd_output("ERROR")
-            return
+            return "ERROR"
 
         nand = self.ssd_file_manager.read_ssd_nand()
-        value = nand[address] if address < len(nand) else 0x00000000
-
-        if value == 0:
-            self.ssd_file_manager.print_ssd_output("0x00000000")
-            return 0x00000000
-
-        self.ssd_file_manager.print_ssd_output(hex(value))
+        value = nand[address]
+        print(value)
+        self.ssd_file_manager.print_ssd_output(value)
         return value
 
-    def Write(self, address, value):
+    def write(self, address=-1, value="ERROR"):
         if not self._is_valid_lba(address):
             self.ssd_file_manager.print_ssd_output("ERROR")
-            return
+            return "ERROR"
 
         if not self._is_valid_value(value):
             self.ssd_file_manager.print_ssd_output("ERROR")
-            return
+            return "ERROR"
 
         self.nand[address] = int(value, 16)
         self.ssd_file_manager.patch_ssd_nand(self.nand)
         self.ssd_file_manager.print_ssd_output(value)
+        return value
 
-    def read(self, address):
-        if 0 <= address < len(self.nand):
-            return self.nand[address]
-        return 0  # out-of-bound read 기본 처리
+def main():
+    ssd = SSD()
+
+    if len(sys.argv) < 3:
+        print("Usage: python ssd.py R [LBA] or python ssd.py W [LBA] [VALUE]")
+        return "ERROR"
+
+    command = sys.argv[1]
+    try:
+        address = int(sys.argv[2])
+    except ValueError:
+        ssd.ssd_file_manager.print_ssd_output("ERROR")
+        return "ERROR"
+
+    if command == "R" and len(sys.argv) == 3:
+        ssd.read(address)
+
+    elif command == "W" and len(sys.argv) == 4:
+        value = sys.argv[3]
+        ssd.write(address, value)
+
+    else:
+        ssd.ssd_file_manager.print_ssd_output("ERROR")
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -1,5 +1,6 @@
 import pytest
-
+import sys
+import src.ssd
 from src.ssd import SSD
 from src.ssd_file_manager import SSDFileManager
 
@@ -9,85 +10,138 @@ def ssd_file_manager_mk(mocker):
     ssd_file_manager_mk = mocker.Mock(spec=SSDFileManager)
     return ssd_file_manager_mk
 
+
 @pytest.fixture
 def ssd_sut(ssd_file_manager_mk):
     ssd_sut = SSD()
     ssd_sut.select_file_manager(ssd_file_manager_mk)
     return ssd_sut
 
+
 def test_ssd_객체_선언_후_처음_read할때_0이_반환되는가(ssd_file_manager_mk, ssd_sut):
-    assert ssd_sut.read(1) == 0
-    assert ssd_sut.read(10) == 0
-    assert ssd_sut.read(100) == 0
+    ssd_file_manager_mk.read_ssd_nand.return_value = ["0x00000000" for _ in range(100)]
+    assert ssd_sut.read(0) == "0x00000000"
+    assert ssd_sut.read(10) == "0x00000000"
+    assert ssd_sut.read(99) == "0x00000000"
+
 
 def test_read가_output에_제대로_된_값을_전달하는가(ssd_file_manager_mk, ssd_sut):
-    pass
+    fake_nand = ["0x00000000" for _ in range(100)]
+    fake_nand[1] = "0x00000001"
+    ssd_file_manager_mk.read_ssd_nand.return_value = fake_nand
+    ssd_sut.read(1)
+    ssd_file_manager_mk.read_ssd_nand.side_effect = ["0x00000001" for _ in range(100)]
+    ssd_file_manager_mk.print_ssd_output.assert_called_with("0x00000001")
 
-def test_read가_제대로_된_값을_리턴하는가():
-    pass
 
-def test_write시_file_manager의_patch가_호출되는가():
-    pass
+def test_read가_제대로_된_값을_리턴하는가(ssd_file_manager_mk, ssd_sut):
+    fake_nand = ["0x00000000" for _ in range(100)]
+    fake_nand[1] = "0x00000001"
+    ssd_file_manager_mk.read_ssd_nand.return_value = fake_nand
+    assert ssd_sut.read(1) == "0x00000001"
 
-def test_write시_file_manager의_print_ssd_output에_제대로_된_값이_들어가는가():
-    pass
 
-def test_write시_nand에_제대로_된_값이_들어가는가():
-    pass
+def test_write시_file_manager의_patch가_호출되는가(ssd_file_manager_mk, ssd_sut):
+    ssd_sut.write(1, "0x00000001")
+    ssd_file_manager_mk.patch_ssd_nand.assert_called()
 
-def test_Read명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수를_한번_호출하는가(ssd_file_manager_mk, ssd_sut):
+
+def test_write시_file_manager의_print_ssd_output에_제대로_된_값이_들어가는가(ssd_file_manager_mk, ssd_sut):
+    ssd_sut.write(1, "0x00000001")
+    ssd_file_manager_mk.print_ssd_output.assert_called_with("0x00000001")
+
+
+def test_read명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수를_한번_호출하는가(ssd_file_manager_mk, ssd_sut):
     WRONG_LBA_ADDRESS = 101
-    ssd_sut.Read(WRONG_LBA_ADDRESS)
+    ssd_sut.read(WRONG_LBA_ADDRESS)
 
     ssd_file_manager_mk.print_ssd_output.assert_called_once()
 
 
-def test_Read명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가(ssd_file_manager_mk, ssd_sut):
+def test_read명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가(ssd_file_manager_mk, ssd_sut):
     WRONG_LBA_ADDRESS = 101
-    ssd_sut.Read(WRONG_LBA_ADDRESS)
+    ssd_sut.read(WRONG_LBA_ADDRESS)
 
     ssd_file_manager_mk.print_ssd_output.assert_called_once_with("ERROR")
 
 
-def test_Read명령어_기록한적없는_LBA_읽을시_0x00000000으로_읽는가(ssd_file_manager_mk, ssd_sut):
+def test_read명령어_기록한적없는_LBA_읽을시_0x00000000으로_읽는가(ssd_file_manager_mk, ssd_sut):
     UNWRITTEN_LBA_ADDRESS = 4
-    fake_nand = [0 for _ in range(100)]
-    fake_nand[1] = 0x00040001
-    fake_nand[2] = 0x00040001
+    fake_nand = ["0x00000000" for _ in range(100)]
+    fake_nand[1] = "0x00040001"
+    fake_nand[2] = "0x00040001"
 
     ssd_file_manager_mk.read_ssd_nand.return_value = fake_nand
-    result = ssd_sut.Read(UNWRITTEN_LBA_ADDRESS)
+    result = ssd_sut.read(UNWRITTEN_LBA_ADDRESS)
 
-    assert result == 0x00000000
+    assert result == "0x00000000"
     ssd_file_manager_mk.print_ssd_output.assert_called_once_with("0x00000000")
 
-def test_Write명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수를_한번_호출하는가(ssd_file_manager_mk, ssd_sut):
+def test_write명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수를_한번_호출하는가(ssd_file_manager_mk, ssd_sut):
     WRONG_LBA_ADDRESS = 101
-    WRITE_VAlUE = 0x00000000
-    ssd_sut.Write(WRONG_LBA_ADDRESS, WRITE_VAlUE)
+    WRITE_VAlUE = '0x00000000'
+    ssd_sut.write(WRONG_LBA_ADDRESS, WRITE_VAlUE)
 
     ssd_file_manager_mk.print_ssd_output.assert_called_once()
 
-def test_Write명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가(ssd_file_manager_mk, ssd_sut):
+def test_write명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가(ssd_file_manager_mk, ssd_sut):
     WRONG_LBA_ADDRESS = 101
-    WRITE_VAlUE = 0x00000000
-    ssd_sut.Write(WRONG_LBA_ADDRESS, WRITE_VAlUE)
+    WRITE_VAlUE = '0x00000000'
+    ssd_sut.write(WRONG_LBA_ADDRESS, WRITE_VAlUE)
 
     ssd_file_manager_mk.print_ssd_output.assert_called_once_with("ERROR")
 
-def test_Read명령어_LBA주소가_입력되지않은경우에도_종료되지않고_정상실행되는가():
-    pass
 
-def test_Write명령어_LBA주소가_입력되지않은경우에도_종료되지않고_정상실행되는가():
-    pass
+def test_read명령어_LBA주소가_입력되지않은경우에도_정상실행되며_출력하는함수_인자에_ERROR를_전달하는가(ssd_file_manager_mk, ssd_sut):
+    try:
+        ssd_sut.read()
+    except Exception as e:
+        pytest.fail()
 
-def test_Write명령어_Value가_입력되지않은경우에도_종료되지않고_정상실행되는가():
-    pass
+    ssd_file_manager_mk.print_ssd_output.assert_called_once_with("ERROR")
 
-def test_Write명령어_Value가_올바르지않은경우_파일매니저의_패치함수를_호출하지않아야한다(ssd_file_manager_mk, ssd_sut):
+
+def test_write명령어_value가_입력되지않은경우에도_정상실행되며_출력하는함수_인자에_ERROR를_전달하는가(ssd_file_manager_mk, ssd_sut):
+    VALID_LBA = 10
+    try:
+        ssd_sut.write(VALID_LBA)
+    except Exception as e:
+        pytest.fail()
+
+    ssd_file_manager_mk.print_ssd_output.assert_called_once_with("ERROR")
+
+
+def test_write명령어에_인자가_없는경우에도_정상실행되며_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가(ssd_file_manager_mk, ssd_sut):
+    try:
+        ssd_sut.write()
+    except Exception as e:
+        pytest.fail()
+
+    ssd_file_manager_mk.print_ssd_output.assert_called_once_with("ERROR")
+
+
+def test_write명령어_Value가_올바르지않은경우_파일매니저의_패치함수를_호출하지않아야한다(ssd_file_manager_mk, ssd_sut):
     LBA = 10
     INVALID_VALUE = "0400000000"
 
-    ssd_sut.Write(LBA, INVALID_VALUE)
+    ssd_sut.write(LBA, INVALID_VALUE)
 
     ssd_file_manager_mk.patch_ssd_nand.assert_not_called()
+
+
+def test_ssd모듈의_read함수는_cmd에서_R명령어로_정상적으로_실행되어야한다(mocker):
+    test_args = ['ssd.py', 'R', '2']
+    mocker.patch('sys.argv', test_args)
+    ssd_read_mock = mocker.patch('src.ssd.SSD.read')
+    src.ssd.main()
+
+    ssd_read_mock.assert_called_once_with(2)
+
+
+def test_ssd모듈의_write함수는_cmd에서_W명령어로_정상적으로_실행되어야한다(mocker):
+    test_args = ['ssd.py', 'W', '2', '0xAAAABBBB']
+    mocker.patch('sys.argv', test_args)
+    ssd_write_mock = mocker.patch('src.ssd.SSD.write')
+    src.ssd.main()
+
+    ssd_write_mock.assert_called_once_with(2, '0xAAAABBBB')


### PR DESCRIPTION
…출력하는함수_인자에_ERROR를_전달하는가

# 📌 Pull Request Template

## 🔍 코드 체크리스트 (Code checklist)
- [x] 본인의 코드가 프로젝트의 코드 스타일 가이드라인을 준수합니다.
- [x] 본인의 코드를 스스로 리뷰했습니다.
- [x] unit test가 작성되었나요?
- [x] unit test가 모두 통과되었나요?
- [x] description을 자세하게 작성하였나요?

---

## 🔍 상세 변경 내용 (Detailed Changes)
ssd.py의 read, write에서 default parameter를 적용하여 입력 parameter가 적을때의 예외처리.
nand에서 읽어온 value를 handling 할때 string 타입으로 다루는것으로 변경


============================= test session starts =============================
collecting ... collected 16 items

test_ssd.py::test_ssd_객체_선언_후_처음_read할때_0이_반환되는가 PASSED
test_ssd.py::test_read가_output에_제대로_된_값을_전달하는가 PASSED
test_ssd.py::test_read가_제대로_된_값을_리턴하는가 PASSED
test_ssd.py::test_write시_file_manager의_patch가_호출되는가 PASSED
test_ssd.py::test_write시_file_manager의_print_ssd_output에_제대로_된_값이_들어가는가 PASSED
test_ssd.py::test_read명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수를_한번_호출하는가 PASSED
test_ssd.py::test_read명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가 PASSED
test_ssd.py::test_read명령어_기록한적없는_LBA_읽을시_0x00000000으로_읽는가 PASSED
test_ssd.py::test_write명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수를_한번_호출하는가 PASSED
test_ssd.py::test_write명령어_잘못된_LBA범위_입력시_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가 PASSED
test_ssd.py::test_read명령어_LBA주소가_입력되지않은경우에도_정상실행되며_출력하는함수_인자에_ERROR를_전달하는가 PASSED
test_ssd.py::test_write명령어_value가_입력되지않은경우에도_정상실행되며_출력하는함수_인자에_ERROR를_전달하는가 PASSED
test_ssd.py::test_write명령어에_인자가_없는경우에도_정상실행되며_파일매니저의_출력하는함수_인자에_ERROR를_전달하는가 PASSED
test_ssd.py::test_write명령어_Value가_올바르지않은경우_파일매니저의_패치함수를_호출하지않아야한다 PASSED
test_ssd.py::test_ssd모듈의_read함수는_cmd에서_R명령어로_정상적으로_실행되어야한다 PASSED
test_ssd.py::test_ssd모듈의_write함수는_cmd에서_W명령어로_정상적으로_실행되어야한다 PASSED